### PR TITLE
Fix for Home Assistant 2023.5.3

### DIFF
--- a/custom_components/bmstools/__init__.py
+++ b/custom_components/bmstools/__init__.py
@@ -87,7 +87,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         HASS_DATA_CLIENT: client,
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 


### PR DESCRIPTION
It was calling async_setup_platforms instead of awaiting async_forward_entry_setups and was failing to load in Home Assistant 2023.5.3.